### PR TITLE
Ci/lint go

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Lint
+
+on:
+  workflow_call:
+
+  push:
+    branches: [main]
+
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-go:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Find changed go files
+        id: changed-go-files
+        uses: tj-actions/changed-files@v34.5.1
+        with:
+          files: |
+            **/*.go
+            go.mod
+            go.sum
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v3.3.1
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        with:
+          go-version: "1.19"
+
+      - name: Lint go code (golangci-lint)
+        uses: golangci/golangci-lint-action@v3
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        with:
+          version: v1.49
+
+      - name: Lint go code (gofumpt)
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        run: |
+          go install mvdan.cc/gofumpt@v0.4.0
+          if [ "$(gofumpt -l .)" != "" ]; then
+            echo "❌ Code is not gofumpt!"
+            exit 1
+          fi
+          echo "✅ Code is gofumpt!"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,60 @@
+run:
+  timeout: 10m
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - cyclop
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goimports
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - lll
+    - makezero
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - stylecheck
+    - tenv
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+
+linters-settings:
+  cyclop:
+    max-complexity: 20
+    skip-tests: true
+  godot:
+    scope: declarations # comments to be checked: `declarations` (default), `toplevel`, or `all`
+  lll:
+    line-length: 135
+output:
+  uniq-by-line: false

--- a/Makefile
+++ b/Makefile
@@ -96,20 +96,24 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
+fmt: ./bin/gofumpt ## Run go fmt against code.
+	./bin/gofumpt -l -w .
+
+./bin/gofumpt:
+	echo "installing $(notdir $@)"
+	GOBIN=${CURDIR}/bin go install mvdan.cc/gofumpt@v0.4.0
 
 .PHONY: golangci
 golangci: ./bin/golangci-lint ## Run golangci against code.
 	./bin/golangci-lint run -v ./...
 
-.PHONY: test
-test: manifests generate fmt golangci envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
-
 ./bin/golangci-lint:
 	echo "installing $(notdir $@)"
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
+
+.PHONY: test
+test: manifests generate fmt golangci envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -99,22 +99,26 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
+.PHONY: golangci
+golangci: ./bin/golangci-lint ## Run golangci against code.
+	./bin/golangci-lint run -v ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt golangci envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+
+./bin/golangci-lint:
+	echo "installing $(notdir $@)"
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
 
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: generate fmt golangci ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
+run: manifests generate fmt golangci ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "krossboard.krossboard.app", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/api/v1alpha1/krossboard_types.go
+++ b/api/v1alpha1/krossboard_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// KoaInstance defines a state of a kube-opex-analytics instance
+// KoaInstance defines a state of a kube-opex-analytics instance.
 type KoaInstance struct {
 	Name               string `json:"name,omitempty"`
 	ContainerPort      int64  `json:"containerPort,omitempty"`
@@ -28,13 +28,13 @@ type KoaInstance struct {
 	ClusterEndpointURL string `json:"clusterEndpoint,omitempty"`
 }
 
-// KbComponentInstance defines a the state of a Krossboard component instance
+// KbComponentInstance defines a the state of a Krossboard component instance.
 type KbComponentInstance struct {
 	Name          string `json:"name,omitempty"`
 	ContainerPort int64  `json:"containerPort,omitempty"`
 }
 
-// KrossboardSpec defines the desired state of Krossboard
+// KrossboardSpec defines the desired state of Krossboard.
 type KrossboardSpec struct {
 	// KrossboardUIImage sets Krossboard UI image
 	//+kubebuilder:default="krossboard/krossboard-ui:latest"
@@ -61,7 +61,7 @@ type KrossboardSpec struct {
 	UseGKEIdentity bool `json:"useGKEIdentity,omitempty"`
 }
 
-// KrossboardStatus defines the observed state of Krossboard
+// KrossboardStatus defines the observed state of Krossboard.
 type KrossboardStatus struct {
 	// KoaInstances contains a list of kube-opex-analytics instances
 	KoaInstances         []KoaInstance         `json:"koaInstances"`
@@ -82,7 +82,7 @@ type Krossboard struct {
 
 //+kubebuilder:object:root=true
 
-// KrossboardList contains a list of Krossboard
+// KrossboardList contains a list of Krossboard.
 type KrossboardList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/controllers/krossboard_controller.go
+++ b/controllers/krossboard_controller.go
@@ -37,7 +37,7 @@ import (
 	kbapi "krossboard-kubernetes-operator/api/v1alpha1"
 )
 
-// KrossboardReconciler reconciles a Krossboard object
+// KrossboardReconciler reconciles a Krossboard object.
 type KrossboardReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -77,7 +77,7 @@ func (kbReconciler *KrossboardReconciler) Reconcile(ctx context.Context, req ctr
 	kbDeployment := &appsv1.Deployment{}
 	err = kbReconciler.Get(ctx, types.NamespacedName{Name: kb.Name, Namespace: kb.Namespace}, kbDeployment)
 	if err != nil && errors.IsNotFound(err) {
-		dep := kbReconciler.deploymentForKrossboard(kb, ctx, req)
+		dep := kbReconciler.deploymentForKrossboard(ctx, kb, req)
 		log.Info("Creating a new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 		err = kbReconciler.Create(ctx, dep)
 		if err != nil {
@@ -142,7 +142,7 @@ func labelsForKrossboard(name string) map[string]string {
 	return map[string]string{"app": "krossboard", "krossboard-kubernetes-operator": name}
 }
 
-// getKrossboardContainers returns a KrossboardStatus object
+// getKrossboardContainers returns a KrossboardStatus object.
 func getKrossboardContainers(pods []corev1.Pod) *kbapi.KrossboardStatus {
 	kbStatus := &kbapi.KrossboardStatus{}
 	for _, pod := range pods {
@@ -183,9 +183,9 @@ func getKrossboardContainers(pods []corev1.Pod) *kbapi.KrossboardStatus {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *KrossboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (kbReconciler *KrossboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kbapi.Krossboard{}).
 		Owns(&appsv1.Deployment{}).
-		Complete(r)
+		Complete(kbReconciler)
 }

--- a/controllers/krossboard_deployment.go
+++ b/controllers/krossboard_deployment.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	krossboardv1alpha1 "krossboard-kubernetes-operator/api/v1alpha1"
 	"strings"
+
+	krossboardv1alpha1 "krossboard-kubernetes-operator/api/v1alpha1"
 
 	"github.com/google/uuid"
 	appsv1 "k8s.io/api/apps/v1"
@@ -36,7 +37,6 @@ const KbReplicaCount = 1
 
 // deploymentForKrossboard returns a krossboard Deployment object
 func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Krossboard, ctx context.Context, req ctrl.Request) *appsv1.Deployment {
-
 	log := ctrllog.FromContext(ctx).WithName("krossboard-kubernetes-operator")
 
 	kbLabels := labelsForKrossboard(m.Name)

--- a/controllers/krossboard_deployment.go
+++ b/controllers/krossboard_deployment.go
@@ -35,14 +35,16 @@ import (
 
 const KbReplicaCount = 1
 
-// deploymentForKrossboard returns a krossboard Deployment object
-func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Krossboard, ctx context.Context, req ctrl.Request) *appsv1.Deployment {
+// deploymentForKrossboard returns a krossboard Deployment object.
+func (kbReconciler *KrossboardReconciler) deploymentForKrossboard(
+	ctx context.Context, m *krossboardv1alpha1.Krossboard, req ctrl.Request,
+) *appsv1.Deployment {
 	log := ctrllog.FromContext(ctx).WithName("krossboard-kubernetes-operator")
 
 	kbLabels := labelsForKrossboard(m.Name)
 	kbDataDir := "/krossboard/db"
-	kbK8sSecretsDir := "/krossboard/secrets"
-	kbCredsDir := "/krossboard/creds"
+	kbK8sSecretsDir := "/krossboard/secrets" //nolint:gosec
+	kbCredsDir := "/krossboard/creds"        //nolint:gosec
 	kbRuntimeDir := "/krossboard/run"
 
 	kbProcessorImage := m.Spec.KrossboardDataProcessorImage
@@ -50,9 +52,9 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 		kbProcessorImage = "krossboard/krossboard-data-processor:latest"
 	}
 
-	kbUiImage := m.Spec.KrossboardUIImage
-	if strings.TrimSpace(kbUiImage) == "" {
-		kbUiImage = "krossboard/krossboard-ui:latest"
+	kbUIImage := m.Spec.KrossboardUIImage
+	if strings.TrimSpace(kbUIImage) == "" {
+		kbUIImage = "krossboard/krossboard-ui:latest"
 	}
 
 	koaImage := m.Spec.KoaImage
@@ -62,7 +64,7 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 
 	kbSecretName := m.Spec.KrossboardSecretName
 	if strings.TrimSpace(kbSecretName) == "" {
-		kbSecretName = "krossboard-secrets"
+		kbSecretName = "krossboard-secrets" //nolint:gosec
 	}
 
 	kbPersistentVolumeClaim := m.Spec.KrossboardPersistentVolumeClaim
@@ -76,7 +78,7 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 	}
 
 	kbSecretResult := &corev1.Secret{}
-	err := r.Client.Get(ctx, secretQuery, kbSecretResult)
+	err := kbReconciler.Client.Get(ctx, secretQuery, kbSecretResult)
 	if err != nil {
 		log.Error(err, "failed to get secret", "Secret.Name", kbSecretName)
 		return &appsv1.Deployment{}
@@ -86,7 +88,7 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 
 	// Credentials of managed clusters are primarily expected in the 'managedClusters' key
 	secretDataB64, secretKeyFound := kbSecretResult.Data["managedClusters"]
-	if secretKeyFound {
+	if secretKeyFound { //nolint:nestif
 		log.Info("using managedClusters key in secret", "Secret.Name", kbSecretName)
 		err := json.Unmarshal(secretDataB64, managedClusters)
 		if err != nil {
@@ -113,7 +115,7 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 
 	koaContainers := []corev1.Container{}
 	koaContainerPort := int32(5483)
-	clusterNames := make([]string, len(*managedClusters))
+	clusterNames := make([]string, 0, len(*managedClusters))
 	for _, managedCluster := range *managedClusters {
 		clusterNames = append(clusterNames, managedCluster.Name)
 		koaContainerName := fmt.Sprintf("kube-opex-analytics-%v", uuid.New().String())
@@ -169,14 +171,14 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 					},
 				},
 			})
-		koaContainerPort += 1
+		koaContainerPort++
 	}
 
 	kbReplicas := int32(KbReplicaCount)
 	kbContainerUsername := "krossboard"
 	koaContainerFsGroup := int64(4583)
 	koaContainerUID := int64(4583)
-	selectedClusterNames := strings.Trim(strings.Join(clusterNames[:], " "), " ")
+	selectedClusterNames := strings.Trim(strings.Join(clusterNames, " "), " ")
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -224,7 +226,7 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 					Containers: append(
 						[]corev1.Container{
 							{
-								Image: kbUiImage,
+								Image: kbUIImage,
 								Name:  "krossboard-ui",
 								Ports: []corev1.ContainerPort{{
 									ContainerPort: 80,
@@ -425,6 +427,7 @@ func (r *KrossboardReconciler) deploymentForKrossboard(m *krossboardv1alpha1.Kro
 		}
 	}
 
-	ctrl.SetControllerReference(m, dep, r.Scheme)
+	_ = ctrl.SetControllerReference(m, dep, kbReconciler.Scheme)
+
 	return dep
 }

--- a/controllers/kubeconfig.go
+++ b/controllers/kubeconfig.go
@@ -37,12 +37,12 @@ const (
 	AuthTypeBasicToken  = 3
 )
 
-// KubeConfigManager holds an object describing a K8s Cluster
+// KubeConfigManager holds an object describing a K8s Cluster.
 type KubeConfigManager struct {
 	Paths []string `json:"path,omitempty"`
 }
 
-// ManagedCluster holds an object describing managed clusters
+// ManagedCluster holds an object describing managed clusters.
 type ManagedCluster struct {
 	Name        string         `json:"name,omitempty"`
 	APIEndpoint string         `json:"apiEndpoint,omitempty"`
@@ -51,7 +51,7 @@ type ManagedCluster struct {
 	AuthType    int            `json:"authType,omitempty"`
 }
 
-// GetManagedClusters lists Kubernetes clusters available in KUBECONFIG
+// GetManagedClusters lists Kubernetes clusters available in KUBECONFIG.
 func (m *KubeConfigManager) GetManagedClusters() map[string]*ManagedCluster {
 	managedClusters := make(map[string]*ManagedCluster)
 	for _, path := range m.Paths {
@@ -70,7 +70,7 @@ func (m *KubeConfigManager) GetManagedClusters() map[string]*ManagedCluster {
 	return managedClusters
 }
 
-// GetManagedClustersFromData lists Kubernetes clusters from a provided KUBECONFIG data
+// GetManagedClustersFromData lists Kubernetes clusters from a provided KUBECONFIG data.
 func (m *KubeConfigManager) GetManagedClustersFromData(data []byte) (map[string]*ManagedCluster, error) {
 	config, err := kclient.Load(data)
 	if err != nil {
@@ -79,7 +79,7 @@ func (m *KubeConfigManager) GetManagedClustersFromData(data []byte) (map[string]
 	return m.GetManagedClustersFromConfig(config), nil
 }
 
-// GetManagedClustersFromConfig lists Kubernetes clusters from a provided KUBECONFIG
+// GetManagedClustersFromConfig lists Kubernetes clusters from a provided KUBECONFIG.
 func (m *KubeConfigManager) GetManagedClustersFromConfig(config *kapi.Config) map[string]*ManagedCluster {
 	managedClusters := make(map[string]*ManagedCluster)
 
@@ -107,7 +107,7 @@ func (m *KubeConfigManager) GetManagedClustersFromConfig(config *kapi.Config) ma
 	return managedClusters
 }
 
-// GetAccessToken retrieves access token from AuthInfo
+// GetAccessToken retrieves access token from AuthInfo.
 func (m *KubeConfigManager) GetAccessToken(authInfo *kapi.AuthInfo) (string, error) {
 	if authInfo == nil {
 		return "", errors.New("no AuthInfo provided")
@@ -119,13 +119,14 @@ func (m *KubeConfigManager) GetAccessToken(authInfo *kapi.AuthInfo) (string, err
 
 	authHookCmd := ""
 	var args []string
-	if authInfo.AuthProvider != nil {
+	switch {
+	case authInfo.AuthProvider != nil:
 		authHookCmd = authInfo.AuthProvider.Config["cmd-path"]
 		args = strings.Split(authInfo.AuthProvider.Config["cmd-args"], " ")
-	} else if authInfo.Exec != nil {
+	case authInfo.Exec != nil:
 		authHookCmd = authInfo.Exec.Command
 		args = authInfo.Exec.Args
-	} else {
+	default:
 		return "", errors.New("no AuthInfo command provided")
 	}
 

--- a/controllers/kubeconfig.go
+++ b/controllers/kubeconfig.go
@@ -18,9 +18,10 @@
 package controllers
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os/exec"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"
@@ -52,7 +53,6 @@ type ManagedCluster struct {
 
 // GetManagedClusters lists Kubernetes clusters available in KUBECONFIG
 func (m *KubeConfigManager) GetManagedClusters() map[string]*ManagedCluster {
-
 	managedClusters := make(map[string]*ManagedCluster)
 	for _, path := range m.Paths {
 		config, err := kclient.LoadFromFile(path)
@@ -81,7 +81,6 @@ func (m *KubeConfigManager) GetManagedClustersFromData(data []byte) (map[string]
 
 // GetManagedClustersFromConfig lists Kubernetes clusters from a provided KUBECONFIG
 func (m *KubeConfigManager) GetManagedClustersFromConfig(config *kapi.Config) map[string]*ManagedCluster {
-
 	managedClusters := make(map[string]*ManagedCluster)
 
 	// FIXME: check usefulness

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,9 +37,11 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -70,7 +72,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
@@ -38,7 +37,6 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 )


### PR DESCRIPTION
This RP reinforces the linting of the go code by proposing the following changes:
- adopt [mvdan/gofumpt](https://github.com/mvdan/gofumpt) for go formatting
- adopt [golangci/golangci-lint](https://github.com/golangci/golangci-lint) for go linting

The `Makefile` has been amended accordingly and a new workflow has been introduced into the CI to ensure that the linters are always happy. Finally, the go code has been minimally reworked to accommodate linters.

I hope that's okay. 😌